### PR TITLE
Fix instructions to set up a dev environment

### DIFF
--- a/docssrc/source/index.rst
+++ b/docssrc/source/index.rst
@@ -32,7 +32,7 @@ We recommend doing the above inside a newly-created python virtual environment.
 Setting up a dev environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Clone the repository
-- Run ``cd type_infer && pip install requirements.txt``
+- Run ``cd type_infer && pip install --editable .``
 - Add it to your python path (e.g. by adding ``export PYTHONPATH='/where/you/cloned/repo':$PYTHONPATH`` as a newline at the end of your ``~/.bashrc`` file)
 - Check that the unit-tests are passing by going into the directory where you cloned and running: ``python -m unittest discover tests``
 


### PR DESCRIPTION
The current documentation on how to setup a development environment is outdated, see https://mindsdb.github.io/type_infer/#setting-up-a-dev-environment.
`pip install requirements.txt` does not work anymore after switching to a `poetry` + `pyproject.toml` workflow.

The CI works because it has been updated to use `pip install -e .`, see https://github.com/mindsdb/type_infer/blob/staging/.github/workflows/python-package.yml#L29.

This PR updates the documentation to match what is done in CI.