### PR TITLE
Fix warning in division by log

### DIFF
--- a/type_infer/helpers.py
+++ b/type_infer/helpers.py
@@ -101,7 +101,10 @@ def get_identifier_description(data: Iterable, column_name: str, data_dtype: dty
         for i, _ in enumerate(str_data[0]):
             N = len(set(x[i] for x in str_data))
             S = st.entropy([*Counter(x[i] for x in str_data).values()])
-            randomness_per_index.append(S / np.log(N))
+            if S == 0:
+                randomness_per_index.append(0.0)
+            else:
+                randomness_per_index.append(S / np.log(N))
 
         if np.mean(randomness_per_index) > 0.95:
             return 'Hash-like identifier'


### PR DESCRIPTION
Fixes #5.

The warning was due to a divide by zero. The log was zero because `N` is equal to one so $\log N = \log 1 = 0$.

But, when $N=1$ the entropy $S$ also is 0 because the formula for entropy reduces to:
$$S = p(x) \times \log p(x)$$
but since $p(x) = 1$, because we only have one element, then we have:
$$S = 1 \times 0 = 0$$
In short, when N is 1 then S is 0 so S / N must be 0 too, which is the solution implemented here.