### PR TITLE
Create docstring for `infer.infer_types`

### DIFF
--- a/type_infer/base.py
+++ b/type_infer/base.py
@@ -9,7 +9,7 @@ class TypeInformation:
     """
     For a dataset, provides information on columns types, how they're used, and any other potential identifiers.
 
-    TypeInformation is generated within ``data.infer_types``, where small samples of each column are evaluated in a custom framework to understand what kind of data type the model is. The user may override data types, but it is recommended to do so within a JSON-AI config file.
+    ``TypeInformation`` is generated within :py:func:`infer.infer_types`, where small samples of each column are evaluated in a custom framework to understand what kind of data type the model is. The user may override data types, but it is recommended to do so within a JSON-AI config file.
 
     :param dtypes: For each column's name, the associated data type inferred.
     :param additional_info: Any possible sub-categories or additional descriptive information.

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -365,6 +365,23 @@ def sample_data(df: pd.DataFrame):
 
 
 def infer_types(data: pd.DataFrame, pct_invalid: float, seed_nr: int = 420, mp_cutoff: int = 1e4) -> TypeInformation:
+    """
+    Infers the data types of each column of the dataset by analyzing a small sample of
+    each column's items.
+
+    Inputs
+    ----------
+    data : pd.DataFrame
+        The input dataset for which we want to infer data type information.
+    pct_invalid : float
+        The percentage, i.e. a float between 0.0 and 100.0, of invalid values that are
+        accepted before failing the type inference for a column.
+    seed_nr : int, optional
+        Seed for the random number generator, by default 420
+    mp_cutoff : int, optional
+        How many elements in the dataframe before switching to parallel processing, by
+        default 1e4.
+    """
     seed(seed_nr)
     type_information = TypeInformation()
     sample_df = sample_data(data)


### PR DESCRIPTION
Work towards improving the docs.

Create a docstring for `infer.infer_types` and update the one reference to it in `base.py` in order to be an hyperlink.