### PR TITLE
Unit tests for the helpers module

### DIFF
--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1,0 +1,24 @@
+import unittest
+
+from type_infer import helpers
+
+
+class TestCastStringToPythonType(unittest.TestCase):
+    def test_numeric_unicode_is_none(self):
+        numeric_unicode = '\u00BC'
+        self.assertTrue(numeric_unicode.isnumeric())
+        self.assertIsNone(helpers.cast_string_to_python_type(numeric_unicode))
+
+    def test_str_is_none(self):
+        self.assertIsNone(helpers.cast_string_to_python_type(''))
+        self.assertIsNone(helpers.cast_string_to_python_type('None'))
+        self.assertIsNone(helpers.cast_string_to_python_type('nan'))
+
+    def test_str_is_int(self):
+        self.assertEqual(helpers.cast_string_to_python_type('1'), 1)
+
+    def test_str_is_float(self):
+        self.assertEqual(helpers.cast_string_to_python_type('1.1'), 1.1)
+        self.assertEqual(helpers.cast_string_to_python_type('1,1'), 1.1)
+        self.assertEqual(helpers.cast_string_to_python_type('1.'), 1.0)
+        self.assertEqual(helpers.cast_string_to_python_type('inf'), float('inf'))

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -22,3 +22,11 @@ class TestCastStringToPythonType(unittest.TestCase):
         self.assertEqual(helpers.cast_string_to_python_type('1,1'), 1.1)
         self.assertEqual(helpers.cast_string_to_python_type('1.'), 1.0)
         self.assertEqual(helpers.cast_string_to_python_type('inf'), float('inf'))
+
+
+class TestIsNanNumeric(unittest.TestCase):
+    def test_numeric_unicode_is_none(self):
+        self.assertTrue(helpers.is_nan_numeric('inf'))
+        self.assertTrue(helpers.is_nan_numeric('nan'))
+        self.assertTrue(helpers.is_nan_numeric(float('inf')))
+        self.assertTrue(helpers.is_nan_numeric(float('nan')))

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -5,9 +5,9 @@ from type_infer import helpers
 
 class TestCastStringToPythonType(unittest.TestCase):
     def test_numeric_unicode_is_none(self):
-        numeric_unicode = '\u00BC'
-        self.assertTrue(numeric_unicode.isnumeric())
-        self.assertIsNone(helpers.cast_string_to_python_type(numeric_unicode))
+        numeric_unicode_str = '\u00BC'
+        self.assertTrue(numeric_unicode_str.isnumeric())
+        self.assertIsNone(helpers.cast_string_to_python_type(numeric_unicode_str))
 
     def test_str_is_none(self):
         self.assertIsNone(helpers.cast_string_to_python_type(''))
@@ -25,8 +25,10 @@ class TestCastStringToPythonType(unittest.TestCase):
 
 
 class TestIsNanNumeric(unittest.TestCase):
-    def test_numeric_unicode_is_none(self):
-        self.assertTrue(helpers.is_nan_numeric('inf'))
+    def test_nan_is_numeric(self):
         self.assertTrue(helpers.is_nan_numeric('nan'))
-        self.assertTrue(helpers.is_nan_numeric(float('inf')))
         self.assertTrue(helpers.is_nan_numeric(float('nan')))
+
+    def test_inf_is_numeric(self):
+        self.assertTrue(helpers.is_nan_numeric('inf'))
+        self.assertTrue(helpers.is_nan_numeric(float('inf')))


### PR DESCRIPTION
Focused on two methods that most seemed to lack coverage: `cast_string_to_python_type` and `is_nan_numeric`

Related to https://github.com/mindsdb/mindsdb/issues/3504