### PR TITLE
added support for timestamps as time (seconds, ms, us, ns and days) 

### DIFF
--- a/tests/unit_tests/test_dates.py
+++ b/tests/unit_tests/test_dates.py
@@ -5,5 +5,43 @@ from type_infer.infer import type_check_date
 
 
 class TestDates(unittest.TestCase):
+
     def test_0_type_check_dates(self):
+        """ Checks parsing of string containing a date to dtype 'date'.
+        """
         self.assertEqual(type_check_date('31/12/2010'), dtype.date)
+    
+    def test_1_type_check_datetime(self):
+        """ Checks parsing of string containing a date to dtype 'datetime'.
+        """
+        self.assertEqual(type_check_date('31/12/2010 23:15:41'), dtype.datetime)
+    
+    def test_2_type_check_timestamp_unix_seconds(self):
+        """ Checks parsing a number containing 1989-12-15T07:30:00 (as seconds
+            since Unix epoch) to dtype 'timestamp'.
+        """
+        self.assertEqual(type_check_date(629721000.0), dtype.timestamp)
+    
+    def test_3_type_check_timestamp_unix_miliseconds(self):
+        """ Checks parsing a number containing 1989-12-15T07:30:00 (as miliseconds
+            since Unix epoch) to dtype 'timestamp'.
+        """
+        self.assertEqual(type_check_date(629721000000.0), dtype.timestamp)
+
+    def test_4_type_check_timestamp_unix_microseconds(self):
+        """ Checks parsing a number containing 1989-12-15T07:30:00 (as microseconds
+            since Unix epoch) to dtype 'timestamp'.
+        """
+        self.assertEqual(type_check_date(629721000000000.0), dtype.timestamp)
+    
+    def test_5_type_check_timestamp_unix_nanoseconds(self):
+        """ Checks parsing a number containing 1989-12-15T07:30:00 (as nanoseconds
+            since Unix epoch) to dtype 'timestamp'.
+        """
+        self.assertEqual(type_check_date(629721000000000000.0), dtype.timestamp)
+    
+    def test_6_type_check_timestamp_julian_days(self):
+        """ Checks parsing a number containing 1989-12-15T07:30:00 (as days since
+            Julian calendar epoch) to dtype 'timestamp'.
+        """
+        self.assertEqual(type_check_date(2447875.81250), dtype.timestamp)

--- a/tests/unit_tests/test_dates.py
+++ b/tests/unit_tests/test_dates.py
@@ -10,18 +10,18 @@ class TestDates(unittest.TestCase):
         """ Checks parsing of string containing a date to dtype 'date'.
         """
         self.assertEqual(type_check_date('31/12/2010'), dtype.date)
-    
+
     def test_1_type_check_datetime(self):
         """ Checks parsing of string containing a date to dtype 'datetime'.
         """
         self.assertEqual(type_check_date('31/12/2010 23:15:41'), dtype.datetime)
-    
+
     def test_2_type_check_timestamp_unix_seconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as seconds
             since Unix epoch) to dtype 'timestamp'.
         """
         self.assertEqual(type_check_date(629721000.0), dtype.timestamp)
-    
+
     def test_3_type_check_timestamp_unix_miliseconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as miliseconds
             since Unix epoch) to dtype 'timestamp'.
@@ -33,13 +33,13 @@ class TestDates(unittest.TestCase):
             since Unix epoch) to dtype 'timestamp'.
         """
         self.assertEqual(type_check_date(629721000000000.0), dtype.timestamp)
-    
+
     def test_5_type_check_timestamp_unix_nanoseconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as nanoseconds
             since Unix epoch) to dtype 'timestamp'.
         """
         self.assertEqual(type_check_date(629721000000000000.0), dtype.timestamp)
-    
+
     def test_6_type_check_timestamp_julian_days(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as days since
             Julian calendar epoch) to dtype 'timestamp'.

--- a/tests/unit_tests/test_dates.py
+++ b/tests/unit_tests/test_dates.py
@@ -18,30 +18,30 @@ class TestDates(unittest.TestCase):
 
     def test_2_type_check_timestamp_unix_seconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as seconds
-            since Unix epoch) to dtype 'timestamp'.
+            since Unix epoch) to dtype 'datetime'.
         """
-        self.assertEqual(type_check_date(629721000.0), dtype.timestamp)
+        self.assertEqual(type_check_date(629721000.0), dtype.datetime)
 
     def test_3_type_check_timestamp_unix_miliseconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as miliseconds
-            since Unix epoch) to dtype 'timestamp'.
+            since Unix epoch) to dtype 'datetime'.
         """
-        self.assertEqual(type_check_date(629721000000.0), dtype.timestamp)
+        self.assertEqual(type_check_date(629721000000.0), dtype.datetime)
 
     def test_4_type_check_timestamp_unix_microseconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as microseconds
-            since Unix epoch) to dtype 'timestamp'.
+            since Unix epoch) to dtype 'datetime'.
         """
-        self.assertEqual(type_check_date(629721000000000.0), dtype.timestamp)
+        self.assertEqual(type_check_date(629721000000000.0), dtype.datetime)
 
     def test_5_type_check_timestamp_unix_nanoseconds(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as nanoseconds
-            since Unix epoch) to dtype 'timestamp'.
+            since Unix epoch) to dtype 'datetime'.
         """
-        self.assertEqual(type_check_date(629721000000000000.0), dtype.timestamp)
+        self.assertEqual(type_check_date(629721000000000000.0), dtype.datetime)
 
     def test_6_type_check_timestamp_julian_days(self):
         """ Checks parsing a number containing 1989-12-15T07:30:00 (as days since
-            Julian calendar epoch) to dtype 'timestamp'.
+            Julian calendar epoch) to dtype 'datetime'.
         """
-        self.assertEqual(type_check_date(2447875.81250), dtype.timestamp)
+        self.assertEqual(type_check_date(2447875.81250), dtype.datetime)

--- a/type_infer/dtype.py
+++ b/type_infer/dtype.py
@@ -5,6 +5,7 @@ class dtype:
     - **Numerical**: Data that should be represented in the form of a number. Currently ``integer``, ``float``, and ``quantity`` are supported.
     - **Categorical**: Data that represents a class or label and is discrete. Currently ``binary``, ``categorical``, and ``tags`` are supported.
     - **Date/Time**: Time-series data that is temporal/sequential. Currently ``date``, and ``datetime`` are supported.
+    - **Timestamp**: Data that represents time in the form of the amount of nano/micro/milli-seconds, seconds after midnight 1970-01-01. Julian days are also supported.
     - **Text**: Data that can be considered as language information.  Currently ``short_text``, and ``rich_text`` are supported. Short text has a small vocabulary (~ 100 words) and is generally a limited number of characters. Rich text is anything with greater complexity.
     - **Complex**: Data types that require custom techniques. Currently ``audio``, ``video`` and ``image`` are available, but highly experimental.
     - **Array**: Data in the form of a sequence where order must be preserved. ``tsarray`` dtypes are for "normal" columns that will be transformed to arrays at a row-level because they will be treated as time series.
@@ -26,6 +27,7 @@ class dtype:
     # Dates and Times (time-series)
     date = "date"
     datetime = "datetime"
+    timestamp = "timestamp"
 
     # Text
     short_text = "short_text"

--- a/type_infer/dtype.py
+++ b/type_infer/dtype.py
@@ -5,7 +5,6 @@ class dtype:
     - **Numerical**: Data that should be represented in the form of a number. Currently ``integer``, ``float``, and ``quantity`` are supported.
     - **Categorical**: Data that represents a class or label and is discrete. Currently ``binary``, ``categorical``, and ``tags`` are supported.
     - **Date/Time**: Time-series data that is temporal/sequential. Currently ``date``, and ``datetime`` are supported.
-    - **Timestamp**: Data that represents time in the form of the amount of nano/micro/milli-seconds, seconds after midnight 1970-01-01. Julian days are also supported.
     - **Text**: Data that can be considered as language information.  Currently ``short_text``, and ``rich_text`` are supported. Short text has a small vocabulary (~ 100 words) and is generally a limited number of characters. Rich text is anything with greater complexity.
     - **Complex**: Data types that require custom techniques. Currently ``audio``, ``video`` and ``image`` are available, but highly experimental.
     - **Array**: Data in the form of a sequence where order must be preserved. ``tsarray`` dtypes are for "normal" columns that will be transformed to arrays at a row-level because they will be treated as time series.
@@ -27,7 +26,6 @@ class dtype:
     # Dates and Times (time-series)
     date = "date"
     datetime = "datetime"
-    timestamp = "timestamp"
 
     # Text
     short_text = "short_text"

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -194,6 +194,7 @@ def type_check_date(element: object) -> str:
 
     return None
 
+
 def count_data_types_in_column(data):
     dtype_counts = Counter()
 

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -148,7 +148,8 @@ def type_check_date(element: object) -> str:
                    'D': 'julian'}
     for unit, origin in valid_units.items():
         try:
-            as_dt = pd.to_datetime(element, unit=unit, origin=origin, errors='raise')
+            as_dt = pd.to_datetime(element, unit=unit, origin=origin,
+                                   errors='raise')
             if min_dt < as_dt < max_dt:
                 is_datetime = True
                 break

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -145,7 +145,6 @@ def type_check_date(element: object) -> str:
     min_dt = pd.to_datetime('1970-01-01 00:00:00', utc=True)
     max_dt = pd.to_datetime('2038-01-19 03:14:08', utc=True)
     valid_units = {'ns': 'unix', 'us': 'unix', 'ms': 'unix', 's': 'unix',
-    # Yes, some people still use Julian Days...
                    'D': 'julian'}
     for unit, origin in valid_units.items():
         try:

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -144,25 +144,17 @@ def type_check_date(element: object) -> str:
     # rather treated as every-day numbers.
     min_dt = pd.to_datetime('1970-01-01 00:00:00', utc=True)
     max_dt = pd.to_datetime('2038-01-19 03:14:08', utc=True)
-    valid_units = ['ns', 'us', 'ms', 's', 'D']
-    for unit in valid_units:
-        # Yes, some people still use Julian Days...
-        if unit == 'D':
-            try:
-                as_dt = pd.to_datetime(element, unit=unit, origin='julian', errors='raise')
-                if min_dt < as_dt < max_dt:
-                    is_datetime = True
-                    break
-            except Exception:
-                pass
-        else:
-            try:
-                as_dt = pd.to_datetime(element, unit=unit, origin='unix', errors='raise')
-                if min_dt < as_dt < max_dt:
-                    is_datetime = True
-                    break
-            except Exception:
-                pass
+    valid_units = {'ns': 'unix', 'us': 'unix', 'ms': 'unix', 's': 'unix',
+    # Yes, some people still use Julian Days...
+                   'D': 'julian'}
+    for unit, origin in valid_units.items():
+        try:
+            as_dt = pd.to_datetime(element, unit=unit, origin=origin, errors='raise')
+            if min_dt < as_dt < max_dt:
+                is_datetime = True
+                break
+        except Exception:
+            pass
     # check if element represents a date-like object.
     # here we don't check for a validity range like with unix-timestamps
     # because dates as string usually represent something more general than

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -132,64 +132,71 @@ def type_check_date(element: object) -> str:
     Check if element corresponds to a date-like object.
     """
     # check if element represents a unix-timestamp
-    isTimestamp = False
+    is_timestamp = False
     # check if element represents a date (no hour/minute/seconds)
-    isDate = False
+    is_date = False
     # check if element represents a datetime (has hour/minute/seconds)
-    isDatetime = False
+    is_datetime = False
 
-    # check if it makes sense to convert element to unix time-stamp by 
-    # evaluating if, when converted, the element represents a number
-    # that is compatible with a Unix timestamp (number of seconds since 1970-01-01T:00:00:00)
+    # check if it makes sense to convert element to unix time-stamp by
+    # evaluating if, when converted, the element represents a number that
+    # is compatible with a Unix timestamp (number of seconds since 1970-01-01T:00:00:00)
     # note that we also check the number is not larger than the "epochalypse time",
     # which is when the unix timestamp becomes larger than 2^32 - 1 seconds. We do
     # this because timestamps outside this range are likely to be unreliable and hence
     # rather treated as every-day numbers.
-    try:
-        unt = ''
-        for unt in ['ns', 'us', 'ms', 's']:
-            dt = pd.to_datetime(element, unit=unt, origin='unix')
-            if ((dt > pd.to_datetime('1970-01-01T:00:00:00', utc=True)) and \
-                (dt < pd.to_datetime('2038-01-19T03:14:08', utc=True))):
-                isTimestamp = True
-                break
-        # yes some kind of people still use Julian Days
-        dt = pd.to_datetime(element, unit='D', origin='julian')
-        if ((dt > pd.to_datetime('1970-01-01T:00:00:00', utc=True)) and \
-            (dt < pd.to_datetime('2038-01-19T03:14:08', utc=True))):
-            isTimestamp = True
-    except Exception as error:
-        pass 
-    # check if element represents a date-like object. 
+    min_dt = pd.to_datetime('1970-01-01T:00:00:00', utc=True)
+    max_dt = pd.to_datetime('2038-01-19T:03:14:08', utc=True)
+    valid_units = ['ns', 'us', 'ms', 's', 'D']
+    for unit in valid_units:
+        # Yes, some people still use Julian Days...
+        if unit == 'D':
+            try:
+                as_dt = pd.to_datetime(element, unit=unit, origin='julian', errors='raise')
+                if min_dt < as_dt < max_dt:
+                    is_timestamp = True
+                    break
+            except Exception:
+                pass
+        else:
+            try:
+                as_dt = pd.to_datetime(element, unit=unit, origin='unix', errors='raise')
+                if min_dt < as_dt < max_dt:
+                    is_timestamp = True
+                    break
+            except Exception:
+                pass
+    # check if element represents a date-like object.
     # here we don't check for a validity range like with unix-timestamps
     # because dates as string usually represent something more general than
     # just the number of seconds since an epoch.
     try:
-        dt = pd.to_datetime(element, errors='raise')
+        as_dt = pd.to_datetime(element, errors='raise')
         # round element day (drop hour/minute/second)
-        dtd = dt.to_period('D').to_timestamp()
+        dt_d = as_dt.to_period('D').to_timestamp()
         # if rounded datetime equals the datetime itself, it means there was not
         # hour/minute/second information to begin with. Mind the 'localize' to
         # avoid time-zone BS to kick in.
-        if dtd == dt.tz_localize(None):
-            isDate = True
+        if dt_d == as_dt.tz_localize(None):
+            is_date = True
         else:
-            isDatetime = True
-    except Exception as error:
+            is_datetime = True
+    except Exception:
         pass
-    
+
     # because of the explicit 'unit' argument when checking for timestamps,
     # element cannot be timestamp AND date/datetime. Similarly, it cannot
     # be both date and datetime.
     rtype = None
-    if isTimestamp:
+    if is_timestamp:
         rtype = dtype.timestamp
-    if isDatetime:
+    if is_datetime:
         rtype = dtype.datetime
-    if isDate:
+    if is_date:
         rtype = dtype.date
-    
+
     return rtype
+
 
 def count_data_types_in_column(data):
     dtype_counts = Counter()
@@ -441,7 +448,7 @@ def infer_types(
     population_size = len(data)
     log.info(f'Analyzing a sample of {sample_size}')
     log.info(
-        f'from a total population of {population_size}, this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.') # noqa
+        f'from a total population of {population_size}, this is equivalent to {round(sample_size*100/population_size, 1)}% of your data.')  # noqa
 
     nr_procs = get_nr_procs(df=sample_df)
     pool_size = min(nr_procs, len(sample_df.columns.values))

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -166,6 +166,9 @@ def type_check_date(element: object) -> str:
                     break
             except Exception:
                 pass
+    if is_timestamp:
+        return dtype.timestamp
+
     # check if element represents a date-like object.
     # here we don't check for a validity range like with unix-timestamps
     # because dates as string usually represent something more general than
@@ -184,19 +187,12 @@ def type_check_date(element: object) -> str:
     except Exception:
         pass
 
-    # because of the explicit 'unit' argument when checking for timestamps,
-    # element cannot be timestamp AND date/datetime. Similarly, it cannot
-    # be both date and datetime.
-    rtype = None
-    if is_timestamp:
-        rtype = dtype.timestamp
     if is_datetime:
-        rtype = dtype.datetime
+        return dtype.datetime
     if is_date:
-        rtype = dtype.date
+        return dtype.date
 
-    return rtype
-
+    return None
 
 def count_data_types_in_column(data):
     dtype_counts = Counter()

--- a/type_infer/infer.py
+++ b/type_infer/infer.py
@@ -145,8 +145,8 @@ def type_check_date(element: object) -> str:
     # which is when the unix timestamp becomes larger than 2^32 - 1 seconds. We do
     # this because timestamps outside this range are likely to be unreliable and hence
     # rather treated as every-day numbers.
-    min_dt = pd.to_datetime('1970-01-01T:00:00:00', utc=True)
-    max_dt = pd.to_datetime('2038-01-19T:03:14:08', utc=True)
+    min_dt = pd.to_datetime('1970-01-01 00:00:00', utc=True)
+    max_dt = pd.to_datetime('2038-01-19 03:14:08', utc=True)
     valid_units = ['ns', 'us', 'ms', 's', 'D']
     for unit in valid_units:
         # Yes, some people still use Julian Days...


### PR DESCRIPTION
This PR adds support to type_infer to handle columns that have time encoded as seconds (or ms, us, ns or Julian days) since epoch a.k.a. unix time.