### PR TITLE
Distributed type inference

### DIFF
--- a/type_infer/base.py
+++ b/type_infer/base.py
@@ -7,13 +7,20 @@ from dataclasses_json import dataclass_json
 @dataclass
 class TypeInformation:
     """
-    For a dataset, provides information on columns types, how they're used, and any other potential identifiers.
+    For a dataset, provides information on columns types.
 
-    ``TypeInformation`` is generated within :py:func:`infer.infer_types`, where small samples of each column are evaluated in a custom framework to understand what kind of data type the model is. The user may override data types, but it is recommended to do so within a JSON-AI config file.
+    ``TypeInformation`` is generated within :py:func:`infer.infer_types`,
+    where a small subset of samples of each column are evaluated in a custom
+    framework to understand what kind of data type the model is. The user
+    may override data types, but it is recommended to do so within a JSON-AI
+    config file.
 
     :param dtypes: For each column's name, the associated data type inferred.
-    :param additional_info: Any possible sub-categories or additional descriptive information.
-    :param identifiers: Columns within the dataset highly suspected of being identifiers or IDs. These do not contain informatic value, therefore will be ignored in subsequent training/analysis procedures unless manually indicated.
+    :param additional_info: Any possible sub-categories or additional descriptive
+           information.
+    :param identifiers: Columns within the dataset highly suspected of being identifiers
+           or IDs. These do not contain useful information, and should therefore be
+           ignored in subsequent training/analysis procedures unless manually indicated.
     """ # noqa
 
     dtypes: Dict[str, str]

--- a/type_infer/column_types.py
+++ b/type_infer/column_types.py
@@ -1,0 +1,233 @@
+"""
+column_types.py
+
+This modules implements a class called `ColumnType` and derived ones which
+are used to keep track of the data type for each column in a tabular dataset.
+
+Currently supported data types are
+
+    - **Categorical**:
+        Data that represents a class or label and is discrete.
+        Currently ``binary``, ``multi-class`` are supported.
+
+    - **Numerical**:
+        Data that should be represented in the form of a number.
+        Currently ``integer``, ``float``, and ``quantity`` are supported.
+
+    - **Date/DateTime**:
+        Time-aware data that is temporal/sequential.
+        Currently ``date`` (no time information), and ``datetime`` are supported.
+
+    - **Text**:
+        Data that can be considered as language information.
+        Currently ``short_text``, and ``rich_text`` are supported. Short text has a
+        small vocabulary (~ 100 words) and is generally a limited number of characters.
+        Rich text is anything with greater complexity.
+
+    `ColumnType` differs from `dtype` in that `ColumnType` has information about the hierarchy
+    of data types. For example, `text` is a more general data type than `numerical`, and
+    in turn `numerical` is more general than `float`. This is useful when performing type inference
+    in distributed environments. Other types are derived from DataType using this.
+"""
+from typing import Tuple
+from typing import Any
+
+
+class ColumnType(object):
+    """
+    Implementatios `ColumnType`.
+    """
+    def __init__(self, type_name: str):
+        """ Initializer
+
+            All column types have a name and are derived from another
+            data type except for `text`, which is the more general one.
+
+            @param type_name: str
+                name of the data type.
+        """
+        self.type_ = type_name
+        self.origin_ = None
+
+    def get_type(self) -> str:
+        """ Returns name of type.
+        """
+        return self.type_
+
+    def get_parent_types(self) -> Tuple[Any]:
+        """ Returns parent data types.
+        """
+        return self.__class__.__bases__
+
+    def has_parent_types(self) -> bool:
+        """ Returns true type is a sub-type.
+
+            Checks for the number of base classes. By construction, all
+            ColumnType objects derive from the 'object' class, and the
+            ColumnType object itself. Hence, 2 must be subtracted from
+            the length of `__bases__`.
+        """
+        n_c = len(self.get_parent_types)
+        return n_c > 2
+
+
+class Invalid(ColumnType):
+    """ Implements invalid column type.
+    """
+    def __init__(self):
+        """ Initializer
+        """
+        super(Invalid, self).__init__('invalid')
+
+
+class Text(ColumnType):
+    """ Implements text column type.
+    """
+    def __init__(self):
+        """ Initializer
+        """
+        super(Text, self).__init__('text')
+
+
+class ShortText(Text):
+    """ Implements short-text column type.
+    """
+    def __init__(self):
+        """ Initializer
+
+            ShortText derives from Text.
+        """
+        self.type_ = 'short-text'
+        super(ShortText, self).__init__()
+
+
+class RichText(Text):
+    """ Implements short-text column type.
+    """
+    def __init__(self):
+        """ Initializer
+
+            ShortText derives from Text.
+        """
+        self.type_ = 'rich-text'
+        super(RichText, self).__init__()
+
+
+class Categorical(Text):
+    """ Implements categorical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Categorical column type derives from text.
+        """
+        self.type_ = 'categorical'
+        super(Categorical, self).__init__()
+
+
+class MultiClass(Categorical):
+    """ Implements multi-class categorical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Categorical column type derives from categorical.
+        """
+        self.type_ = 'multi-class'
+        super(MultiClass, self).__init__()
+
+
+class Binary(MultiClass):
+    """ Implements binary column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Categorical column type derives from multi-class.
+        """
+        self.type_ = 'binary'
+        super(Binary, self).__init__()
+
+
+class NonCategorical(Text):
+    """ Implements non-categorical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Non-categorical column type derives from text.
+        """
+        self.type_ = 'non-categorical'
+        super(NonCategorical, self).__init__()
+
+
+class Numerical(NonCategorical):
+    """ Implements numerical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Numerical column type derives from non-categorical.
+        """
+        self.type_ = 'numerical'
+        super(Numerical, self).__init__()
+
+
+class Complex(Numerical):
+    """ Implements complex-valued numerical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Real column type derives from numerical.
+        """
+        self.type_ = 'complex'
+        super(Complex, self).__init__()
+
+
+class Real(Complex):
+    """ Implements real-valued numerical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Real column type derives from complex.
+        """
+        self.type_ = 'real'
+        super(Real, self).__init__()
+
+
+class Ordinal(Real):
+    """ Implements integer-valued numerical column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            Ordinal column type derives from real.
+        """
+        self.type_ = 'real'
+        super(Ordinal, self).__init__()
+
+
+class Date(NonCategorical):
+    """ Implements date-time column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            DateTime column type derives from non-categorical.
+        """
+        self.type_ = 'date'
+        super(Date, self).__init__()
+
+
+class DateTime(Date):
+    """ Implements date-time column type.
+    """
+    def __init__(self):
+        """ Initializer.
+
+            DateTime column type derives from date.
+        """
+        self.type_ = 'datetime'
+        super(DateTime, self).__init__()

--- a/type_infer/dtype.py
+++ b/type_infer/dtype.py
@@ -1,16 +1,55 @@
+"""
+dtype.py
+
+This modules implements a class called `dtype`, `ColumnType` and derived ones which
+are used to keep track of the data type for each column in a tabular dataset.
+
+Currently supported data types are
+
+    - **Numerical**:
+        Data that should be represented in the form of a number.
+        Currently ``integer``, ``float``, and ``quantity`` are supported.
+    - **Categorical**:
+        Data that represents a class or label and is discrete.
+        Currently ``binary``, ``categorical``, and ``tags`` are supported.
+    - **Date/Time**:
+        Time-aware data that is temporal/sequential.
+        Currently ``date`` (no time information), and ``datetime`` are supported.
+    - **Text**:
+        Data that can be considered as language information.
+        Currently ``short_text``, and ``rich_text`` are supported. Short text has a
+        small vocabulary (~ 100 words) and is generally a limited number of characters.
+        Rich text is anything with greater complexity.
+
+    - **Complex**:
+        Data types that require custom techniques.
+        Currently ``audio``, ``video`` and ``image`` are available.
+        Support for this data types is highly experimental.
+
+    - **Array**:
+        Data in the form of a sequence where order must be preserved. ``tsarray``
+        dtypes are for "normal" columns that will be transformed to arrays at a row-level
+        because they will be treated as time series.
+
+    - **Miscellaneous**:
+        Miscellaneous data descriptors include ``empty``, an explicitly unknown
+        value versus ``invalid``, a data type not currently supported.
+
+    `DataType` differs from `dtype` in that `DataType` has information about the hierarchy
+    of data types. For example, `text` is a more general data type than `number`, and
+    in turn `number` is more general than `float`. This is useful when performing type inference
+    in distributed environments. Other types are derived from DataType using this.
+"""
+
+
 class dtype:
     """
-    Definitions of all data types currently supported:
+    Implementatios `data_type`.
 
-    - **Numerical**: Data that should be represented in the form of a number. Currently ``integer``, ``float``, and ``quantity`` are supported.
-    - **Categorical**: Data that represents a class or label and is discrete. Currently ``binary``, ``categorical``, and ``tags`` are supported.
-    - **Date/Time**: Time-series data that is temporal/sequential. Currently ``date``, and ``datetime`` are supported.
-    - **Text**: Data that can be considered as language information.  Currently ``short_text``, and ``rich_text`` are supported. Short text has a small vocabulary (~ 100 words) and is generally a limited number of characters. Rich text is anything with greater complexity.
-    - **Complex**: Data types that require custom techniques. Currently ``audio``, ``video`` and ``image`` are available, but highly experimental.
-    - **Array**: Data in the form of a sequence where order must be preserved. ``tsarray`` dtypes are for "normal" columns that will be transformed to arrays at a row-level because they will be treated as time series.
-    - **Miscellaneous**: Miscellaneous data descriptors include ``empty``, an explicitly unknown value versus ``invalid``, a data type not currently supported.
-
-    Custom data types may be implemented here as a flag for subsequent treatment and processing. You are welcome to include your own definitions, so long as they do not override the existing type names (alternatively, if you do, please edit subsequent parts of the preprocessing pipeline to correctly indicate how you want to deal with these data types).
+    Custom data types may be implemented here as a flag for subsequent treatment and processing.
+    You are welcome to include your own definitions, so long as they do not override the existing
+    type names (alternatively, if you do, please edit subsequent parts of the preprocessing pipeline
+    to correctly indicate how you want to deal with these data types).
     """ # noqa
 
     # Numerical type data
@@ -45,3 +84,4 @@ class dtype:
     # Misc (Unk/NaNs)
     empty = "empty"
     invalid = "invalid"
+

--- a/type_infer/dtype.py
+++ b/type_infer/dtype.py
@@ -9,7 +9,7 @@ class dtype:
     - **Complex**: Data types that require custom techniques. Currently ``audio``, ``video`` and ``image`` are available, but highly experimental.
     - **Array**: Data in the form of a sequence where order must be preserved. ``tsarray`` dtypes are for "normal" columns that will be transformed to arrays at a row-level because they will be treated as time series.
     - **Miscellaneous**: Miscellaneous data descriptors include ``empty``, an explicitly unknown value versus ``invalid``, a data type not currently supported.
-    
+
     Custom data types may be implemented here as a flag for subsequent treatment and processing. You are welcome to include your own definitions, so long as they do not override the existing type names (alternatively, if you do, please edit subsequent parts of the preprocessing pipeline to correctly indicate how you want to deal with these data types).
     """ # noqa
 

--- a/type_infer/type_inspector.py
+++ b/type_infer/type_inspector.py
@@ -1,0 +1,165 @@
+""" type_inspector.py
+
+This module implements Inspector, a system that uses a pre-trained deep learning model to
+infer data types from columns. The inspector must be trained before-hand or weights shall
+be provided by MindsDB in order to work.
+"""
+import json
+
+import torch
+import pandas
+import numpy
+from transformers import BertModel, BertTokenizer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+from sklearn.preprocessing import LabelEncoder
+
+
+class Inspector:
+    """ Implementation of Inspector.
+    """
+    def __init__(self):
+        """
+        """
+        self.data_ = pandas.DataFrame
+        self.classifier_ = RandomForestClassifier(n_estimators=100)
+        self.embeddings_ = []
+        self.emb_targets_ = []
+
+        self.targets_ = {}
+        self.enc_ = LabelEncoder()
+        self.tokenizer_ = torch.nn.Module
+        self.model_ = torch.nn.Module
+        self.device_ = torch.device
+
+    def load_model(self):
+        """
+        """
+        # Initialize the tokenizer with a pretrained model
+        self.tokenizer_ = BertTokenizer.from_pretrained('bert-base-uncased')
+        self.model_ = BertModel.from_pretrained('bert-base-uncased', output_hidden_states=True)
+
+        # Set the device to GPU (cuda) if available, otherwise stick with CPU
+        self.device_ = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.model_ = self.model_.to(self.device_)
+        self.model_.eval()
+
+    def load_data(self, data_path: str, target_path: str):
+        """
+        """
+        self.data_ = pandas.read_csv(data_path, engine='python', nrows=1000)
+        if target_path is not None:
+            f = open(target_path, 'r')
+            self.targets_ = json.loads(f.read())
+
+            for t in self.data_.columns.to_list():
+                if t not in self.targets_:
+                    print(t)
+                    raise ValueError(f"column {t} not in target list.")
+
+    def get_column_embeddings(self, col_name: str):
+        """
+        """
+        data = self.data_[col_name].astype(str).to_list()
+        data_as_str = ' '.join(data)
+        embeddings = []
+        for i in range(0, len(data_as_str), 512):
+            tokens = self.tokenizer_.encode(data_as_str[i:i + 512])
+            ids = numpy.asarray(tokens)
+            # Convert the list of IDs to a tensor of IDs
+            ids = torch.LongTensor(ids)
+            ids = torch.unsqueeze(ids, 0)
+            ids = ids.to(self.device_)
+            with torch.no_grad():
+                out = self.model_(input_ids=ids)
+            # we only want the hidden_states
+            hidden_states = out[2]
+            sentence_embedding = torch.mean(hidden_states[-1], dim=1).squeeze()
+            embeddings.append(sentence_embedding.cpu().numpy())
+
+        return embeddings
+
+    def add_data(self):
+        """
+        """
+        emb_data = []
+        tgt_data = []
+        for col_name, target in self.targets_.items():
+            emb = self.get_column_embeddings(col_name)
+            tgt_data += [target] * len(emb)
+            emb = numpy.asarray(emb)
+            print(emb.shape)
+            emb_data.append(emb)
+        self.embeddings_ += emb_data
+        self.emb_targets_ += tgt_data
+
+    def train(self):
+        """
+        """
+        emb_data = numpy.concatenate(self.embeddings_, axis=0).reshape((-1, 768))
+        tgt_data = self.enc_.fit_transform(self.emb_targets_)
+        trainX, testX, trainY, testY = train_test_split(emb_data, tgt_data)
+
+        self.classifier_ = self.classifier_.fit(trainX, trainY)
+
+        ground_truth = self.enc_.inverse_transform(testY)
+        prediction = self.enc_.inverse_transform(self.classifier_.predict(testX))
+
+        print(classification_report(ground_truth, prediction))
+
+    def run(self):
+        """
+        """
+        col_names = self.data_.columns.to_list()
+        emb_data = []
+        col_list = []
+        for col_name in col_names:
+            emb = self.get_column_embeddings(col_name)
+            emb = numpy.asarray(emb)
+            col_list += [col_name] * emb.shape[0]
+            emb_data.append(emb)
+        emb_data = numpy.concatenate(emb_data, axis=0).reshape((-1, 768))
+        print(len(col_list), emb_data.shape)
+        prediction = self.enc_.inverse_transform(self.classifier_.predict(emb_data))
+
+        results = pandas.DataFrame()
+        results['column_name'] = col_list
+        results['column_type'] = prediction
+
+        return results
+
+
+if __name__ == '__main__':
+
+    ins = Inspector()
+    ins.load_model()
+    ins.load_data('../tests/data/airline_sentiment.csv',
+                  '../tests/data/airline_sentiment.json')
+    ins.add_data()
+    ins.load_data('/srv/storage/ml/datasets/individual_household_power_comsumption/data.csv',
+                  '/srv/storage/ml/datasets/individual_household_power_comsumption/data.json')
+    ins.add_data()
+    ins.load_data('/srv/storage/ml/datasets/used_car_price/data.csv',
+                  '/srv/storage/ml/datasets/used_car_price/data.json')
+    ins.add_data()
+    print("training...")
+    ins.train()
+    print("")
+
+    print("running...")
+    # ins.load_data('../tests/data/stack_overflow_survey_sample.csv', None)
+    # ins.load_data('/srv/storage/ml/datasets/individual_household_power_comsumption/data.csv', None)
+    ins.load_data('/srv/storage/ml/datasets/airline_delays/data.csv', None)
+    results = ins.run()
+    print("")
+
+    for col_name in results['column_name'].unique():
+        weights = results[results['column_name'] == col_name].value_counts()
+        weights = weights / weights.sum()
+        inferred_types = weights.index.get_level_values('column_type').values
+        probs = weights.values
+        print(col_name)
+        for t, pt in zip(inferred_types, probs):
+            print(f"type: {t} with probability: {pt:2.1f}")
+        print("")


### PR DESCRIPTION
The current implementation of `type_infer` is not suitable to be used in distributed compute environments 
(i.e. non-scalable); currently, `type_infer` can only be executed in a single node and needs to load data into memory.  This makes `type_infer` unsuitable to analyze large datasets that do not fit in RAM.

The internal workings of `type_infer` allow for a relatively straightforward implementation to allow execution in distributed compute environments; one could use sub-sets of columns (each subset loaded into a different worker) to infer the data types, and then apply something like a voting mechanism to choose a type over the other.

The voting mechanism shall be aware of data type hierarchy. For example, consider the the case of having 4 workers: worker 1 identifies a subset of a column to be of type `text` while workers 2, 3, and 4 identify the rest of the subsets as being of type `integer`. Because `text` is a more general data type than `integer` (one level higher in the data type hierarchy), the entire column should be casted as `text` instead of `integer`, even if there are more votes for the former. It might be important to mention that the current implementation does not handle this situation which might seem like an edge-case but it is likely very common.

The proposed implementation shall use `torch.disitrbuted` to distribute the work across nodes. Because `torch` is a heavy dependency, this capability shall be available only if the user install `type_infer` by running

```
pip install type_infer[distributed]
```

All of the distributed modules should be encapsulated into a sub-module called `distributed` to avoid breaking the already existing code-base. 
 