### PR TITLE
suppress nltk output when downloading punkt

### DIFF
--- a/type_infer/rule_based/helpers.py
+++ b/type_infer/rule_based/helpers.py
@@ -15,7 +15,7 @@ from type_infer.dtype import dtype
 try:
     nltk.data.find('tokenizers/punkt')
 except LookupError:
-    nltk.download('punkt')
+    nltk.download('punkt', quiet=True)
 
 try:
     from nltk.corpus import stopwords


### PR DESCRIPTION
NLTK outputs the following when downloading punkt in the mindsdb docker container:

```
[nltk_data] Downloading package punkt to /root/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
```

It annoys me and it pollutes the logs :) 

NOTE: We already use `quiet=True` when downloading `stopwords`